### PR TITLE
fix: strip parent dangling conflict commas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,11 @@ const END_RE = />{7,}/g
 const isDiff = str =>
   str.match(OURS_RE) && str.match(THEIRS_RE) && str.match(END_RE)
 
+// Removing a conflict block can leave the synthesized parent with a dangling
+// comma before the closing object/array delimiter.
+const stripParentDanglingCommas = str =>
+  str.replace(/,(\s*[}\]])(?=\s*(?:[,}\]]|$))/g, '$1')
+
 const parseConflictJSON = (str, reviver, prefer) => {
   prefer = prefer || 'ours'
   if (prefer !== 'theirs' && prefer !== 'ours') {
@@ -64,7 +69,7 @@ const parseConflictJSON = (str, reviver, prefer) => {
   })
 
   // this will throw if either piece is not valid JSON, that's intended
-  const parent = parseJSON(pieces.parent, reviver)
+  const parent = parseJSON(stripParentDanglingCommas(pieces.parent), reviver)
   const ours = parseJSON(pieces.ours, reviver)
   const theirs = parseJSON(pieces.theirs, reviver)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,6 +15,28 @@ t.test('conflicted', async t => {
   t.matchSnapshot(parseJSON(conflicted, null, 'theirs'), 'prefer theirs')
 })
 
+t.test('conflict on final object property', async t => {
+  const finalPropertyConflict = [
+    '{',
+    '  "foo": "foo",',
+    '<'.repeat(7) + ' HEAD',
+    '  "bar": "bar1"',
+    '='.repeat(7),
+    '  "bar": "bar2"',
+    '>'.repeat(7) + ' git-conflict-2',
+    '}',
+  ].join('\n')
+
+  t.strictSame(parseJSON(finalPropertyConflict), {
+    foo: 'foo',
+    bar: 'bar1',
+  })
+  t.strictSame(parseJSON(finalPropertyConflict, null, 'theirs'), {
+    foo: 'foo',
+    bar: 'bar2',
+  })
+})
+
 t.test('isDiff', async t => {
   t.notOk(parseJSON.isDiff(JSON.stringify({})), '{} is not a diff conflict')
   t.notOk(parseJSON.isDiff(JSON.stringify({ a: 1 })), '{a:1} is not a diff conflict')


### PR DESCRIPTION
Fixes #115.

When a conflict block covers the final property of an object, the synthesized parent JSON can keep the separator comma from the previous top-level line:

```json
{
  "foo": "foo",
}
```

That parent is only an intermediate baseline used for diff resolution, but parsing it currently throws before the selected side can be applied.

This strips dangling commas from the synthesized parent fragment before parsing it. The selected `ours` and `theirs` fragments are still parsed normally, so invalid user-provided conflict sides continue to fail.

Verification:

- `npx tap --no-coverage test/basic.js`
- `npm run eslint -- lib/index.js test/basic.js`
- `git diff --check`
- `npm test` passes tests, coverage, and eslint locally, then fails only in `template-oss-check` because the generated repository template wants unrelated `.github` branch/template updates. I did not include those unrelated tooling changes in this bugfix PR.
